### PR TITLE
[JIRA-MF-2784]: Removed mandatory option

### DIFF
--- a/request/client.go
+++ b/request/client.go
@@ -64,7 +64,7 @@ func (Client) CheckUpdate(ctx *gin.Context) {
 					updateInfoRedis.PackageHash = *packag.Hash
 					updateInfoRedis.PackageSize = *packag.Size
 					updateInfoRedis.IsAvailable = true
-					updateInfoRedis.IsMandatory = true
+					updateInfoRedis.IsMandatory = false
 					label := strconv.Itoa(*packag.Id)
 					updateInfoRedis.Label = label
 
@@ -104,7 +104,7 @@ func (Client) CheckUpdate(ctx *gin.Context) {
 			updateInfo.PackageHash = updateInfoRedis.PackageHash
 			updateInfo.PackageSize = updateInfoRedis.PackageSize
 			updateInfo.IsAvailable = true
-			updateInfo.IsMandatory = true
+			updateInfo.IsMandatory = false
 			updateInfo.Label = updateInfoRedis.Label
 			updateInfo.DownloadUrl = updateInfoRedis.DownloadUrl
 			updateInfo.Description = updateInfoRedis.Description


### PR DESCRIPTION
This pull request modifies the `CheckUpdate` function in `request/client.go` to change the update behavior. Specifically, it updates the `IsMandatory` field to be set to `false` instead of `true` for both `updateInfoRedis` and `updateInfo` objects.

Key change:

* [`request/client.go`](diffhunk://#diff-3f9ae5f6e0bc02077798851f584d54a1df6d7d64338b01141fc78e85fef6ccf6L67-R67): Updated the `IsMandatory` field in the `CheckUpdate` function to be set to `false`, making updates non-mandatory. [[1]](diffhunk://#diff-3f9ae5f6e0bc02077798851f584d54a1df6d7d64338b01141fc78e85fef6ccf6L67-R67) [[2]](diffhunk://#diff-3f9ae5f6e0bc02077798851f584d54a1df6d7d64338b01141fc78e85fef6ccf6L107-R107)